### PR TITLE
Correct invalid mix version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add `hedwig_slack` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:hedwig_slack, "0.1"}]
+  [{:hedwig_slack, "~> 0.1"}]
 end
 ```
 


### PR DESCRIPTION
Updates the README to resolve the error you get if you copy and paste the `deps` as-is:

``` shell
$ mix deps.get
** (Mix) Required version "0.1" for package hedwig_slack is incorrectly specified (from: mix.exs)
```
