### PR TITLE
Add Web API and handle responder identity

### DIFF
--- a/lib/hedwig_slack/web_api.ex
+++ b/lib/hedwig_slack/web_api.ex
@@ -1,0 +1,13 @@
+defmodule HedwigSlack.WebAPI do
+  alias HedwigSlack.HTTP
+
+  @doc "https://api.slack.com/methods/chat.meMessage"
+  def chat_postmessage(%{token: _, channel: _, text: _} = args) do
+    HTTP.form_post("/chat.postMessage", args)
+  end
+
+  @doc "https://api.slack.com/methods/chat.postMessage"
+  def chat_memessage(%{token: _, channel: _, text: _} = args) do
+    HTTP.form_post("/chat.meMessage", args)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule HedwigSlack.Mixfile do
     [mod: {HedwigSlack, []},
      applications: [
       :logger,
-      :hackney,
+      :httpoison,
       :hedwig,
       :poison,
       :websocket_client
@@ -28,8 +28,8 @@ defmodule HedwigSlack.Mixfile do
   end
 
   defp deps do
-    [{:hackney, "~> 1.6"},
-     {:hedwig, "~> 1.0"},
+    [{:httpoison, "~> 0.10.0"},
+     {:hedwig, path: "../hedwig"},
      {:poison, "~> 3.0"},
      {:websocket_client, "~> 1.1"},
 

--- a/test/hedwig_slack/web_api_test.exs
+++ b/test/hedwig_slack/web_api_test.exs
@@ -1,0 +1,50 @@
+defmodule HedwigSlack.WebAPITest do
+  use ExUnit.Case
+
+  import Plug.Conn
+
+  alias HedwigSlack.WebAPI
+
+  describe "Web API methods" do
+    setup :setup_endpoint
+
+    test "posts a message", %{server: server} do
+      token = "abc123"
+
+      Bypass.expect server, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/api/chat.postMessage"
+        assert conn.query_string == ""
+        assert get_req_header(conn, "content-type") == ["application/x-www-form-urlencoded; charset=utf-8"]
+
+        resp(conn, 200, ~s({"ok":true}))
+      end
+
+      {:ok, %{status: 200, body: body}} = WebAPI.chat_postmessage(%{channel: "test", text: "hi", token: token})
+      assert %{"ok" => true} == body
+    end
+
+    test "posts a me_message", %{server: server} do
+      token = "abc123"
+
+      Bypass.expect server, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/api/chat.meMessage"
+        assert conn.query_string == ""
+        assert get_req_header(conn, "content-type") == ["application/x-www-form-urlencoded; charset=utf-8"]
+
+        resp(conn, 200, ~s({"ok":true}))
+      end
+
+      {:ok, %{status: 200, body: body}} = WebAPI.chat_memessage(%{channel: "test", text: "hi", token: token})
+      assert %{"ok" => true} == body
+    end
+  end
+
+  defp setup_endpoint(_) do
+    server = Bypass.open()
+    :ok = Application.put_env(:hedwig_slack, :endpoint, "http://localhost:#{server.port}/api")
+
+    {:ok, server: server}
+  end
+end


### PR DESCRIPTION
Hi, this is a first go at using the Slack Web API to allow for responders to define identities (custom name and emoji/thumbnails) they will use when sending messages. There are some limits based on spotty (buggy) areas of the Slack API but for most things it works well. Additionally, for emotes, since the RTC doesn't support message formatting, I've switched out the use of it for the Web API.

There is an accompanying changeset to the base Hedwig package as well.