### PR TITLE
Fix compile warning generated with Elixir 1.5

### DIFF
--- a/lib/hedwig_slack/connection.ex
+++ b/lib/hedwig_slack/connection.ex
@@ -18,7 +18,7 @@ defmodule HedwigSlack.Connection do
   end
 
   def start_link(url, owner) do
-    :websocket_client.start_link(to_char_list(url), __MODULE__, owner)
+    :websocket_client.start_link(to_charlist(url), __MODULE__, owner)
   end
 
   def ws_send(pid, msg) do


### PR DESCRIPTION
Fix a small Elixir 1.5 compile warning when running `mix hedwig.gen.robot`